### PR TITLE
Update install.txt

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -7,4 +7,4 @@ INSTALLATION
 Before this plugin will activate, you *must* follow the installation
 instructions here:
 
-https://github.com/STRML/SublimeLinter-jsxhint
+https://github.com/SublimeLinter/SublimeLinter-jsxhint


### PR DESCRIPTION
Fixes a wrong url being mentioned when installing SublimeLinter-jsxhint in Sublime.
