### PR TITLE
Rename 6to5 to babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Before using this plugin, you must ensure that `jsxhint` is installed on your sy
 
 1. Install a JSX syntax file. A syntax file is no longer included in this repo. Supported syntaxes are:
 
-* [Babel-Sublime](https://github.com/babel/babel-sublime) (supports additional ES6 features)
+* [babel-sublime](https://github.com/babel/babel-sublime) (supports additional ES6 features)
 * [Sublime-React](https://github.com/reactjs/sublime-react)
 
 

--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,9 @@ class JSXHint(Linter):
 
     """Provides an interface to the jsxhint executable."""
 
-    syntax = ('jsx', 'javascript_jsx', 'javascript (jsx)', 'javascript 6to5')
+    # "javascript 6to5" is now "javascript (babel)", but lets leave 6to5
+    # for a bit while users migrate
+    syntax = ('jsx', 'javascript_jsx', 'javascript (jsx)', 'javascript (babel)', 'javascript 6to5')
     executable = 'jsxhint'
     config_file = ('--config', '.jshintrc', '~')
     version_re = r'\bv(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
Hey @STRML, we changed the name of 6to5 to babel. I'm waiting on https://github.com/wbond/package_control_channel/pull/4099 before I merge https://github.com/6to5/6to5-sublime/pull/38. So, I'll ping you again when this PR should be merged. Thank you!
